### PR TITLE
Fix mistake

### DIFF
--- a/ROLES/messages/0
+++ b/ROLES/messages/0
@@ -5,8 +5,8 @@
 <@&454917884637085706> - All of the moderators in the server. Please ping only for urgent issues when category mods fail to respond.
 There are also individual roles for moderators who oversee each category of the server, please ping them for category-specific issues: <@&878878675423096852>, <@&673384065327431700>, <@&1171342031801552929>, <@&559418180880039948>, <@&915343194013696021>, <@&559418497571225606>, <@&933124742276321420>
 
-<@&1116341107140333740> - Verifiers and managers of the [Hardest Maps Clear List](<https://docs.google.com/spreadsheets/d/1A88F3X2lOQJry-Da2NpnAr-w5WDrkjDtg7Wt0kLCiz8>). Feel free to ping them for any questions related to the website or to submit a video.
-<@&849715261347201095> - Verifiers and managers of the [Custom Map Golden List](<https://goldberries.net/>). Feel free to ping them for submissions.
+<@&1116341107140333740> - Verifiers and managers of the [Hardest Maps Clear List](<https://docs.google.com/spreadsheets/d/1A88F3X2lOQJry-Da2NpnAr-w5WDrkjDtg7Wt0kLCiz8>). Feel free to ping them for submissions.
+<@&849715261347201095> - Verifiers and managers of the [Custom Map Golden List](<https://goldberries.net/>). Feel free to ping them for any questions related to the website or to submit a video.
 <@&615240487518994462> - Developers and moderators of [CelesteNet](<https://celestenet.0x0a.de>), the multiplayer mod.
 <@&673394998913400873> - Creators and maintainers of [Everest](<https://everestapi.github.io>), the community mod loader. Please ping them for bug reports.
 <@&673391557939953684> - Experienced modders able to assist with issues. Feel free to ping them for help.


### PR DESCRIPTION
Accidentally changed hard list team description instead of modded golden team's. This patch fixes the change to do follow the intent.