### PR TITLE
Restructure #modding_help message

### DIFF
--- a/MODDING_HELP/messages/0
+++ b/MODDING_HELP/messages/0
@@ -1,19 +1,22 @@
-Heya, and welcome to <#953393160464269402>!
-This is your new home to ask for help with modding the game - make sure you've read the channel description and this post before making your own.
-If you're looking to get set up with modding in the first place, check out <#928422006985203822> ⁠and the pins for any other channels that may be relevant.
+Heya, and welcome to <#953393160464269402>! This is your new home to ask for help with modding or troubleshooting the game, vanilla or not.
+**Please make sure you've read the channel description and this post before making your own.**
 
-When making a post, make sure you've read through all of the following, as well as any resources:
+If you're looking to get set up with modding in the first place, check out <#928422006985203822> and the pins for any other channels that may be relevant.
 
-# - **If Everest itself is crashing, check if it is a known/common crash [here](<https://github.com/EverestAPI/Resources/wiki/Common-Crashes>).**
+Before making a post, read through the following points:
 
-- Add a clear title briefly describing your issue - this helps us with seeing whether we're able to help
-- Make sure to add any relevant tags, such as :warning: Crash
+# **If Everest or Celeste itself is crashing, please check if it is [a known/common crash](<https://github.com/EverestAPI/Resources/wiki/Common-Crashes>) first.**
+- **Try updating Everest and your mods.** It's possible that an update may have already fixed your issue.
+- **Make sure to include necessary logs.**
+  - For Everest crashes, the "Oooops!" crash screen will tell you what file to upload, along with a button to open the folder it's in. If your issue is not a crash, you can find `log.txt` or `error_log.txt` in the folder Celeste is installed to.
+  - For Olympus issues, its logs location is described in the </olympuslogs:1172673423042949141> command.
+- **Describe your problem *as accurately as you can***, so that we can focus on solving it immediately instead of having to figure out what issue you're having in the first place.
+- **Make sure to add any relevant tags**, such as :warning: Crash
+- Following these steps makes the lives of the people who are trying to help you much easier. Please respect their time.
 
-- If you're having trouble installing Everest, check this wiki page for some common issues and their fixes:
+## **If you're having trouble installing Everest, check this wiki page for some common issues and their fixes:**
 - <https://github.com/EverestAPI/Resources/wiki/Everest-Install-Issues>
 
-- For more general issues/helper information, please read the Everest/Helper Wiki first:
+## **For more general issues/helper information, please read the Everest/Helper Wiki first:**
 - <https://github.com/EverestAPI/Resources/wiki>
 - <https://github.com/EverestAPI/ModResources/wiki>
-
-- If you're experiencing a crash or other error, include your log.txt/error_log.txt/log-sharp.txt


### PR DESCRIPTION
Rewords the `#modding_help` pinned post to include vanilla Celeste crashes as valid posts. It also updates the post guidelines to make them clearer and more visible at a glance.