### PR TITLE
Return prior link formatting on rule 6

### DIFF
--- a/RULES/embeds/0
+++ b/RULES/embeds/0
@@ -25,7 +25,7 @@
     },
     {
       "name": "🔹__Rule 6:__ No excessive venting",
-      "value": ">>> If you are having thoughts about self harm, it is important to talk to someone trained to help you, so be sure to look into local resources for people who can help you help yourself. You can find a support helpline in your country using <https://findahelpline.com/>. Alternatively, you can use this US Resource [(Link)](http://www.suicide.org/suicide-hotlines.html) for US suicide hotlines by state, or this International Resource [(Link)](http://www.suicide.org/international-suicide-hotlines.html) for non-US hotlines by country. Jokes about suicide or self harm are not allowed."
+      "value": ">>> If you are having thoughts about self harm, it is important to talk to someone trained to help you, so be sure to look into local resources for people who can help you help yourself. You can find a support helpline in your country using <https://findahelpline.com/>. Alternatively, you can use this [US Resource (Link)](http://www.suicide.org/suicide-hotlines.html) for US suicide hotlines by state, or this [International Resource (Link)](http://www.suicide.org/international-suicide-hotlines.html) for non-US hotlines by country. Jokes about suicide or self harm are not allowed."
     },
     {
       "name": "🔹__Rule 7:__ No warez, piracy, or malware",


### PR DESCRIPTION
The link be the whole section rather than just the (link) allows it stand out from the text, making it much more visible